### PR TITLE
Export the main package, so it can be extended

### DIFF
--- a/org.scala-ide.equinox-weaving-launcher/META-INF/MANIFEST.MF
+++ b/org.scala-ide.equinox-weaving-launcher/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Require-Bundle:
  org.eclipse.pde.ui,
  org.eclipse.ui.workbench 
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Export-Package: org.scalaide.ew.launcher


### PR DESCRIPTION
Hi Miles,

I worked on cleaning up the experimental Scala debugger, so I doesn't rely on a running JDT debugger anymore.
To be able to launch the Scala debugger, I am adding tweaked launch configuration delegate to the existing launch configuration types, so the user can choose which debugger to use.
It is working fine apart from the fact that sdt.debug cannot see the weaving launcher at runtime, with the current configuration.

The change is to export the weaving launcher classes, so sdt.debug can extend and tweak them to launch the Scala debugger.

When the merge is done, a new build should be pushed to your update-site

Luc
