### PR TITLE
Makes the build work with jdk7

### DIFF
--- a/org.scala-ide.equinox-weaving-launcher.build/pom.xml
+++ b/org.scala-ide.equinox-weaving-launcher.build/pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <tycho.version>0.12.0</tycho.version>
+    <tycho.version>0.15.0</tycho.version>
     <maven.compiler.source>1.5</maven.compiler.source>
     <maven.compiler.target>1.5</maven.compiler.target>
     <encoding>UTF-8</encoding>

--- a/org.scala-ide.equinox-weaving-launcher/pom.xml
+++ b/org.scala-ide.equinox-weaving-launcher/pom.xml
@@ -14,7 +14,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.tycho</groupId>
+        <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <version>${tycho.version}</version>
         <configuration>


### PR DESCRIPTION
The old version of tycho fails with jdk7, updated to the latest version: 0.15.0
